### PR TITLE
Change message_logger_ros to use ROS2 foxy, while keeping the externa…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,8 @@ cmake_minimum_required(VERSION 3.5)
 project(message_logger)
 
 # Find Catkin
-find_package(catkin REQUIRED)
+find_package(catkin_simple REQUIRED)
+catkin_simple()
 
 include(CMakeDependentOption)
 cmake_dependent_option(MELO_USE_COUT "Use std::cout" OFF
@@ -41,28 +42,15 @@ endif()
 
 add_definitions(-std=c++14 -fPIC -Wall)
 
-include_directories(
-  include
-  ${catkin_INCLUDE_DIRS}
-  ${rclcpp_INCLUDE_DIRS}
-)
-
-add_library(${PROJECT_NAME} SHARED
+cs_add_library(${PROJECT_NAME}
+  src/log/globals.cpp
   src/time/Time.cpp
   src/time/TimeStd.cpp
 )
+target_link_libraries(${PROJECT_NAME} ${rclcpp_LIBRARIES})
 
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${rclcpp_LIBRARIES})
-
-install(DIRECTORY include/${PROJECT_NAME}/ ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_INCLUDE_DESTINATION}/ ${rclcpp_INCLUDE_DIRS}
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-  PATTERN "*.in" EXCLUDE
-)
-install(TARGETS ${PROJECT_NAME} 
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-)
+cs_install()
+cs_export()
 
 ##########
 ## Test ##

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,75 +2,54 @@ cmake_minimum_required(VERSION 3.5)
 
 project(message_logger)
 
-# Find Catkin
-find_package(catkin_simple REQUIRED)
-catkin_simple()
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
 
 include(CMakeDependentOption)
 cmake_dependent_option(MELO_USE_COUT "Use std::cout" OFF
                        "DEFINED ENV{ROS_DISTRO}" ON)
 
-# Configure header file before catkin_package
-catkin_destinations()
-configure_file(
-  include/message_logger/log/log_messages_backend_config.hpp.in
-  ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_INCLUDE_DESTINATION}/log/log_messages_backend_config.hpp @ONLY
-)
-
 if(NOT MELO_USE_COUT)
-  message(STATUS "Building message_logger using ros.")
-  find_package(rclcpp REQUIRED)
-  catkin_package(
-    INCLUDE_DIRS include ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_INCLUDE_DESTINATION} ${rclcpp_INCLUDE_DIRS}
-    LIBRARIES ${PROJECT_NAME}
-    DEPENDS ${rclcpp_LIBRARIES}
-    CFG_EXTRAS message_logger.cmake
-  )
+  message(WARNING "Building message_logger using ros.")
 else()
-  message(STATUS "Building message_logger using std::cout.")
-  catkin_package(
-    INCLUDE_DIRS include ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_INCLUDE_DESTINATION}
-    LIBRARIES ${PROJECT_NAME}
-    CATKIN_DEPENDS
-    CFG_EXTRAS message_logger.cmake
-  )
+  message(WARNING "Building message_logger using std::cout.")
 endif()
+
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/include/message_logger/log/log_messages_backend_config.hpp.in
+  ${CMAKE_CURRENT_BINARY_DIR}/include/message_logger/log/log_messages_backend_config.hpp @ONLY
+)
 
 if(DEFINED MELO_FUNCTION_PRINTS)
   add_definitions(-DMELO_FUNCTION_PRINTS)
 endif()
 
-add_definitions(-std=c++14 -fPIC -Wall)
+# Build
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
 
-cs_add_library(${PROJECT_NAME}
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+ament_auto_add_library(${PROJECT_NAME}
   src/log/globals.cpp
   src/time/Time.cpp
   src/time/TimeStd.cpp
 )
-target_link_libraries(${PROJECT_NAME} ${rclcpp_LIBRARIES})
 
-cs_install()
-cs_export()
+# Install
+install(
+  FILES ${CMAKE_CURRENT_BINARY_DIR}/include/message_logger/log/log_messages_backend_config.hpp
+  DESTINATION include/message_logger/log
+)
 
-##########
-## Test ##
-##########
-if(CATKIN_ENABLE_TESTING)
-  catkin_add_gtest(test_${PROJECT_NAME}
-    test/EmptyTests.cpp
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/test
-  )
+ament_auto_package()
 
-  if(TARGET test_${PROJECT_NAME})
-    target_link_libraries( test_${PROJECT_NAME}
-      ${PROJECT_NAME}
-      ${catkin_LIBRARIES}
-      pthread
-      gtest_main
-    )
-    find_package(cmake_code_coverage QUIET)
-    if(cmake_code_coverage_FOUND)
-      add_gtest_coverage()
-    endif(cmake_code_coverage_FOUND)
-  endif()
+# Test
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_add_gtest(empty_test test/EmptyTests.cpp)
+  target_link_libraries(empty_test)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required(VERSION 3.5)
 
 project(message_logger)
 
@@ -18,10 +18,11 @@ configure_file(
 
 if(NOT MELO_USE_COUT)
   message(STATUS "Building message_logger using ros.")
+  find_package(rclcpp REQUIRED)
   catkin_package(
-    INCLUDE_DIRS include ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_INCLUDE_DESTINATION}
+    INCLUDE_DIRS include ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_INCLUDE_DESTINATION} ${rclcpp_INCLUDE_DIRS}
     LIBRARIES ${PROJECT_NAME}
-    CATKIN_DEPENDS roscpp
+    DEPENDS ${rclcpp_LIBRARIES}
     CFG_EXTRAS message_logger.cmake
   )
 else()
@@ -38,11 +39,12 @@ if(DEFINED MELO_FUNCTION_PRINTS)
   add_definitions(-DMELO_FUNCTION_PRINTS)
 endif()
 
-add_definitions(-std=c++11 -fPIC -Wall)
+add_definitions(-std=c++14 -fPIC -Wall)
 
 include_directories(
   include
   ${catkin_INCLUDE_DIRS}
+  ${rclcpp_INCLUDE_DIRS}
 )
 
 add_library(${PROJECT_NAME} SHARED
@@ -50,13 +52,13 @@ add_library(${PROJECT_NAME} SHARED
   src/time/TimeStd.cpp
 )
 
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${rclcpp_LIBRARIES})
 
-install(DIRECTORY include/${PROJECT_NAME}/ ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_INCLUDE_DESTINATION}/
+install(DIRECTORY include/${PROJECT_NAME}/ ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_INCLUDE_DESTINATION}/ ${rclcpp_INCLUDE_DIRS}
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
   PATTERN "*.in" EXCLUDE
 )
-install(TARGETS ${PROJECT_NAME}
+install(TARGETS ${PROJECT_NAME} 
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
@@ -75,6 +77,7 @@ if(CATKIN_ENABLE_TESTING)
     target_link_libraries( test_${PROJECT_NAME}
       ${PROJECT_NAME}
       ${catkin_LIBRARIES}
+      pthread
       gtest_main
     )
     find_package(cmake_code_coverage QUIET)

--- a/include/message_logger/log/globals.hpp
+++ b/include/message_logger/log/globals.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <rclcpp/clock.hpp>
+
+namespace message_logger {
+namespace log {
+
+extern rclcpp::Clock clock;
+
+} // namespace log
+} // namespace message_logger

--- a/include/message_logger/log/log_messages_ros.hpp
+++ b/include/message_logger/log/log_messages_ros.hpp
@@ -43,12 +43,13 @@
 #include <rclcpp/clock.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include "message_logger/log/globals.hpp"
 #include "message_logger/log/log_messages_backend.hpp"
 
 namespace message_logger {
 namespace log {
 
-rclcpp::Clock clock;
+extern rclcpp::Clock clock;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #define MELO_LOG(level, ...) \

--- a/include/message_logger/log/log_messages_ros.hpp
+++ b/include/message_logger/log/log_messages_ros.hpp
@@ -40,12 +40,15 @@
 */
 #pragma once
 
-#include <ros/console.h>
+#include <rclcpp/clock.hpp>
+#include <rclcpp/rclcpp.hpp>
 
 #include "message_logger/log/log_messages_backend.hpp"
 
 namespace message_logger {
 namespace log {
+
+rclcpp::Clock clock;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #define MELO_LOG(level, ...) \
@@ -55,27 +58,27 @@ namespace log {
   switch (level) { \
   case message_logger::log::levels::Debug: \
     { \
-    ROS_DEBUG("%s", melo_stringstream.str().c_str()); \
+    RCLCPP_DEBUG(rclcpp::get_logger(""), "%s", melo_stringstream.str().c_str()); \
     } \
     break; \
   case message_logger::log::levels::Info: \
     { \
-    ROS_INFO("%s", melo_stringstream.str().c_str()); \
+    RCLCPP_INFO(rclcpp::get_logger(""), "%s", melo_stringstream.str().c_str()); \
     } \
     break; \
   case message_logger::log::levels::Warn: \
     { \
-    ROS_WARN("%s", melo_stringstream.str().c_str()); \
+    RCLCPP_WARN(rclcpp::get_logger(""), "%s", melo_stringstream.str().c_str()); \
     } \
     break; \
   case message_logger::log::levels::Error: \
     { \
-      ROS_ERROR("%s", melo_stringstream.str().c_str()); \
+      RCLCPP_ERROR(rclcpp::get_logger(""), "%s", melo_stringstream.str().c_str()); \
     } \
     break; \
   case message_logger::log::levels::Fatal: \
     { \
-    ROS_FATAL("%s", melo_stringstream.str().c_str()); \
+    RCLCPP_FATAL(rclcpp::get_logger(""), "%s", melo_stringstream.str().c_str()); \
     std::stringstream melo_assert_stringstream; \
     melo_assert_stringstream << message_logger::log::colorFatal << message_logger::common::internal::melo_string_format(__VA_ARGS__) << message_logger::log::getResetColor(); \
     message_logger::common::internal::melo_throw_exception<message_logger::log::melo_fatal>("[FATAL] ", __FUNCTION__,__FILE__,__LINE__, melo_assert_stringstream.str()); \
@@ -83,7 +86,7 @@ namespace log {
     break; \
   default: \
     { \
-    ROS_INFO(__VA_ARGS__); \
+    RCLCPP_INFO(rclcpp::get_logger(""), __VA_ARGS__); \
     } \
     break; \
   } \
@@ -97,27 +100,27 @@ namespace log {
   switch (level) { \
   case message_logger::log::levels::Debug: \
     { \
-    ROS_DEBUG_STREAM(melo_stringstream.str()); \
+    RCLCPP_DEBUG_STREAM(rclcpp::get_logger(""), melo_stringstream.str()); \
     } \
     break; \
   case message_logger::log::levels::Info: \
     { \
-    ROS_INFO_STREAM(melo_stringstream.str()); \
+    RCLCPP_INFO_STREAM(rclcpp::get_logger(""), melo_stringstream.str()); \
     } \
     break; \
   case message_logger::log::levels::Warn: \
     { \
-    ROS_WARN_STREAM(melo_stringstream.str()); \
+    RCLCPP_WARN_STREAM(rclcpp::get_logger(""), melo_stringstream.str()); \
     } \
     break; \
   case message_logger::log::levels::Error: \
     { \
-    ROS_ERROR_STREAM(melo_stringstream.str()); \
+    RCLCPP_ERROR_STREAM(rclcpp::get_logger(""), melo_stringstream.str()); \
     } \
     break; \
   case message_logger::log::levels::Fatal: \
     { \
-    ROS_FATAL_STREAM(melo_stringstream.str()); \
+    RCLCPP_FATAL_STREAM(rclcpp::get_logger(""), melo_stringstream.str()); \
     std::stringstream melo_assert_stringstream;             \
     melo_assert_stringstream << message_logger::log::colorFatal << message << message_logger::log::getResetColor(); \
     message_logger::common::internal::melo_throw_exception<message_logger::log::melo_fatal>("[FATAL] ", __FUNCTION__,__FILE__,__LINE__, melo_assert_stringstream.str()); \
@@ -125,7 +128,7 @@ namespace log {
     break; \
   default: \
     { \
-    ROS_INFO_STREAM(message); \
+    RCLCPP_INFO_STREAM(rclcpp::get_logger(""), message); \
     } \
     break; \
   } \
@@ -145,27 +148,27 @@ namespace log {
       switch (level) { \
       case message_logger::log::levels::Debug: \
         { \
-        ROS_DEBUG_THROTTLE(rate, "%s", melo_stringstream.str().c_str()); \
+        RCLCPP_DEBUG_THROTTLE(rclcpp::get_logger(""), message_logger::log::clock, rate*1000, "%s", melo_stringstream.str().c_str()); \
         } \
         break; \
       case message_logger::log::levels::Info: \
         { \
-        ROS_INFO_THROTTLE(rate, "%s", melo_stringstream.str().c_str()); \
+        RCLCPP_INFO_THROTTLE(rclcpp::get_logger(""), message_logger::log::clock, rate*1000, "%s", melo_stringstream.str().c_str()); \
         } \
         break; \
       case message_logger::log::levels::Warn: \
         { \
-        ROS_WARN_THROTTLE(rate, "%s", melo_stringstream.str().c_str()); \
+        RCLCPP_WARN_THROTTLE(rclcpp::get_logger(""), message_logger::log::clock, rate*1000, "%s", melo_stringstream.str().c_str()); \
         } \
         break; \
       case message_logger::log::levels::Error: \
         { \
-          ROS_ERROR_THROTTLE(rate, "%s", melo_stringstream.str().c_str()); \
+          RCLCPP_ERROR_THROTTLE(rclcpp::get_logger(""), message_logger::log::clock, rate*1000, "%s", melo_stringstream.str().c_str()); \
         } \
         break; \
       case message_logger::log::levels::Fatal: \
         { \
-        ROS_FATAL_THROTTLE(rate, "%s", melo_stringstream.str().c_str()); \
+        RCLCPP_FATAL_THROTTLE(rclcpp::get_logger(""), message_logger::log::clock, rate*1000, "%s", melo_stringstream.str().c_str()); \
         std::stringstream melo_assert_stringstream; \
         melo_assert_stringstream << message_logger::log::colorFatal << message_logger::common::internal::melo_string_format(__VA_ARGS__) << message_logger::log::getResetColor(); \
         message_logger::common::internal::melo_throw_exception<message_logger::log::melo_fatal>("[FATAL] ", __FUNCTION__,__FILE__,__LINE__, melo_assert_stringstream.str()); \
@@ -173,7 +176,7 @@ namespace log {
         break; \
       default: \
         { \
-        ROS_INFO_THROTTLE(rate, __VA_ARGS__); \
+        RCLCPP_INFO_THROTTLE(rclcpp::get_logger(""), message_logger::log::clock, rate*1000, __VA_ARGS__); \
         } \
         break; \
       } \
@@ -187,27 +190,27 @@ namespace log {
       switch (level) { \
       case message_logger::log::levels::Debug: \
         { \
-        ROS_DEBUG_STREAM_THROTTLE(rate, melo_stringstream.str()); \
+        RCLCPP_DEBUG_STREAM_THROTTLE(rclcpp::get_logger(""), message_logger::log::clock, rate*1000, melo_stringstream.str()); \
         } \
         break; \
       case message_logger::log::levels::Info: \
         { \
-        ROS_INFO_STREAM_THROTTLE(rate, melo_stringstream.str()); \
+        RCLCPP_INFO_STREAM_THROTTLE(rclcpp::get_logger(""), message_logger::log::clock, rate*1000, melo_stringstream.str()); \
         } \
         break; \
       case message_logger::log::levels::Warn: \
         { \
-        ROS_WARN_STREAM_THROTTLE(rate, melo_stringstream.str()); \
+        RCLCPP_WARN_STREAM_THROTTLE(rclcpp::get_logger(""), message_logger::log::clock, rate*1000, melo_stringstream.str()); \
         } \
         break; \
       case message_logger::log::levels::Error: \
         { \
-        ROS_ERROR_STREAM_THROTTLE(rate, melo_stringstream.str()); \
+        RCLCPP_ERROR_STREAM_THROTTLE(rclcpp::get_logger(""), message_logger::log::clock, rate*1000, melo_stringstream.str()); \
         } \
         break; \
       case message_logger::log::levels::Fatal: \
         { \
-        ROS_FATAL_STREAM_THROTTLE(rate, melo_stringstream.str()); \
+        RCLCPP_FATAL_STREAM_THROTTLE(rclcpp::get_logger(""), message_logger::log::clock, rate*1000, melo_stringstream.str()); \
         std::stringstream melo_assert_stringstream;             \
         melo_assert_stringstream << message_logger::log::colorFatal << message << message_logger::log::getResetColor(); \
         message_logger::common::internal::melo_throw_exception<message_logger::log::melo_fatal>("[FATAL] ", __FUNCTION__,__FILE__,__LINE__, melo_assert_stringstream.str()); \
@@ -215,7 +218,7 @@ namespace log {
         break; \
       default: \
         { \
-        ROS_INFO_STREAM_THROTTLE(rate, message); \
+        RCLCPP_INFO_STREAM_THROTTLE(rclcpp::get_logger(""), message_logger::log::clock, rate*1000, message); \
         } \
         break; \
       } \

--- a/package.xml
+++ b/package.xml
@@ -7,8 +7,10 @@
   <maintainer email="rdiethelm@anybotics.com">Remo Diethelm</maintainer>
   <license>BSD</license>
   <author email="cgehring@anybotics.com">Christian Gehring</author>
-  <buildtool_depend>catkin</buildtool_depend>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+
   <depend>rclcpp</depend>
+  
   <test_depend>gtest</test_depend>
-<!--   <test_depend>cmake_code_coverage</test_depend> -->
 </package>

--- a/package.xml
+++ b/package.xml
@@ -8,7 +8,7 @@
   <license>BSD</license>
   <author email="cgehring@anybotics.com">Christian Gehring</author>
   <buildtool_depend>catkin</buildtool_depend>
-  <depend>roscpp</depend>
+  <depend>rclcpp</depend>
   <test_depend>gtest</test_depend>
 <!--   <test_depend>cmake_code_coverage</test_depend> -->
 </package>

--- a/src/log/globals.cpp
+++ b/src/log/globals.cpp
@@ -1,0 +1,9 @@
+#include "message_logger/log/globals.hpp"
+
+namespace message_logger {
+namespace log {
+
+rclcpp::Clock clock{};
+
+} // namespace log
+} // namespace message_logger

--- a/src/time/TimeStd.cpp
+++ b/src/time/TimeStd.cpp
@@ -113,6 +113,8 @@ TimeStd::~TimeStd()
 }
 
 TimeStd& TimeStd::from(uint32_t sec, uint32_t nsec) {
+  sec_ = sec;
+  nsec_ = nsec;
   normalizeSecNSec(sec_, nsec_);
   return *this;
 }


### PR DESCRIPTION
This gets message_logger working with ROS2 foxy.

I tried to keep the observable behaviour the same as much as possible.

Points that need to be discussed are:
- Does Anybotics have any plans of doing this conversion themselves?
- Do we keep this as a catkin package (and therefore compatible with large parts of our codebase), or do we change this to an ament package?
- Do we change the interface, to be more in line with the new interface of RCLCPP_INFO