### PR TITLE
Fix/remove unwated message on stderr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,9 +13,9 @@ cmake_dependent_option(MELO_USE_COUT "Use std::cout" OFF
 unset(CATKIN_INSTALL_INTO_PREFIX_ROOT)
 
 if(NOT MELO_USE_COUT)
-  message(WARNING "Building message_logger using ros.")
+  message(STATUS "Building message_logger using ros.")
 else()
-  message(WARNING "Building message_logger using std::cout.")
+  message(STATUS "Building message_logger using std::cout.")
 endif()
 
 configure_file(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,9 @@ include(CMakeDependentOption)
 cmake_dependent_option(MELO_USE_COUT "Use std::cout" OFF
                        "DEFINED ENV{ROS_DISTRO}" ON)
 
+# Avoid output on stderr by unsetting catkin variable not used - https://github.com/colcon/colcon-ros/issues/83#issue-504270285
+unset(CATKIN_INSTALL_INTO_PREFIX_ROOT)
+
 if(NOT MELO_USE_COUT)
   message(WARNING "Building message_logger using ros.")
 else()


### PR DESCRIPTION
PR fixes warning messages written to stderr and forwarded by colcon to user when compiling for the first time in a fresh ROS2 workspace.

warning level for `message`  si changed to `INFO`, given that a general information is provided to the user and not a real warning message.